### PR TITLE
Fix handleBlanks() to to handle adjacent clozes

### DIFF
--- a/js/blanks.js
+++ b/js/blanks.js
@@ -251,7 +251,7 @@ H5P.Blanks = (function ($, Question) {
         clozeStart += 1;
       }
       question = question.slice(0, clozeStart - 1) + replacer + question.slice(clozeEnd);
-      clozeEnd -= clozeEnd - clozeStart - replacer.length;
+      clozeEnd -= clozeEnd - clozeStart - replacer.length + 1;
 
       // Find the next cloze
       clozeStart = question.indexOf('*', clozeEnd);


### PR DESCRIPTION
If I have two \*Siamese\*\*twin\* Clozes. That have no space in Between. The Procedure failed. This fix will make this available.