### PR TITLE
Fix handleBlanks() to support html-Tags

### DIFF
--- a/js/blanks.js
+++ b/js/blanks.js
@@ -242,6 +242,10 @@ H5P.Blanks = (function ($, Question) {
         continue; // No end
       }
       var clozeContent = question.substring(clozeStart, clozeEnd);
+      // Strip away Markup-Language Elements from clozeContent.
+      var temp = document.createElement('div');
+      temp.innerHTML = clozeContent;
+      clozeContent = temp.textContent || temp.innerText || '';
       var replacer = '';
       if (clozeContent.length) {
         replacer = handler(self.parseSolution(clozeContent));

--- a/js/blanks.js
+++ b/js/blanks.js
@@ -241,11 +241,7 @@ H5P.Blanks = (function ($, Question) {
       if (clozeEnd === -1) {
         continue; // No end
       }
-      var clozeContent = question.substring(clozeStart, clozeEnd);
-      // Strip away Markup-Language Elements from clozeContent.
-      var temp = document.createElement('div');
-      temp.innerHTML = clozeContent;
-      clozeContent = temp.textContent || temp.innerText || '';
+      var clozeContent = question.substring(clozeStart, clozeEnd).replace(/<[^>]+>/ig,"");
       var replacer = '';
       if (clozeContent.length) {
         replacer = handler(self.parseSolution(clozeContent));


### PR DESCRIPTION
Although I can put some styling of my text within a cloze (surrounded by *), the question cannot be answered correctly, if i do somthing like this. Example: This is a large cloze where I stupidly put \*some **bold** in\*.
This is shown in https://h5p.org/node/357524