### PR TITLE
Fix overflow when growing fields cause line breaks

### DIFF
--- a/js/blanks.js
+++ b/js/blanks.js
@@ -366,7 +366,11 @@ H5P.Blanks = (function ($, Question) {
       self.triggerXAPI('interacted');
     });
 
-    self.on('resize', function () {
+    self.on('resize', function (event) {
+      if (event.data && event.data.skip === true) {
+        return; // prevent resize loop if triggered by self
+      }
+
       self.resetGrowTextField();
     });
 
@@ -418,6 +422,8 @@ H5P.Blanks = (function ($, Question) {
         // Apply width that wraps input
         $input.width(width + static_min_pad);
       }
+      // Changing width can cause linebreak and require resize
+      self.trigger('resize', {skip: true});
     }, 1);
   };
 

--- a/js/blanks.js
+++ b/js/blanks.js
@@ -366,8 +366,8 @@ H5P.Blanks = (function ($, Question) {
       self.triggerXAPI('interacted');
     });
 
-    self.on('resize', function (event) {
-      if (event.data && event.data.skip === true) {
+    self.on('resize', function () {
+      if (self.autoGrowResizeDelay) {
         return; // prevent resize loop if triggered by self
       }
 
@@ -423,7 +423,10 @@ H5P.Blanks = (function ($, Question) {
         $input.width(width + static_min_pad);
       }
       // Changing width can cause linebreak and require resize
-      self.trigger('resize', {skip: true});
+      clearTimeout(self.autoGrowResizeDelay);
+      self.autoGrowResizeDelay = setTimeout(function () {
+        self.trigger('resize');
+      }, 1);
     }, 1);
   };
 


### PR DESCRIPTION
When merged in, this pull request will fix content overflow that's not covered by a necessary resize event.

Currently, when the user enters text into the input fields of blanks, the field grows, can cause a line break and thus cause an overflow of content. That overflow is not covered by a resize of the container, so some content such as the check button will (partially) be invisible.