### PR TITLE
HFP-2881 Fix apostrophe on iOS

### DIFF
--- a/js/cloze.js
+++ b/js/cloze.js
@@ -201,7 +201,7 @@
      */
     this.toString = function () {
       var extra = defaultUserAnswer ? ' value="' + defaultUserAnswer + '"' : '';
-      var result = '<span class="h5p-input-wrapper"><input type="text" class="h5p-text-input" autocomplete="off" autocapitalize="off"' + extra + '></span>';
+      var result = '<span class="h5p-input-wrapper"><input type="text" class="h5p-text-input" autocomplete="off" autocapitalize="off" spellcheck="false"' + extra + '></span>';
       self.length = result.length;
       return result;
     };


### PR DESCRIPTION
The virtual keyboard of iOS does not produce an apostrophe, but a left single quotation mark or a right single quotation mark if it is using smart quotes. Can be turned off by setting the input fields' spellcheck attribute to false.