### PR TITLE
Fix getMaxScore

### DIFF
--- a/js/blanks.js
+++ b/js/blanks.js
@@ -117,6 +117,10 @@ H5P.Blanks = (function ($, Question) {
         self.shiftPressed = false;
       }
     });
+
+    // Using instructions as label for our text groups
+    this.labelId = 'h5p-blanks-instructions-' + Blanks.idCounter;
+    this.content = self.createQuestions();
   }
 
   // Inheritance
@@ -153,14 +157,11 @@ H5P.Blanks = (function ($, Question) {
       }
     }
 
-    // Using instructions as label for our text groups
-    const labelId = 'h5p-blanks-instructions-' + Blanks.idCounter;
-
     // Register task introduction text
-    self.setIntroduction('<div id="' + labelId + '">' + self.params.text + '</div>');
+    self.setIntroduction('<div id="' + this.labelId + '">' + self.params.text + '</div>');
 
     // Register task content area
-    self.setContent(self.createQuestions(labelId), {
+    self.setContent(self.content, {
       'class': self.params.behaviour.separateLines ? 'h5p-separate-lines' : ''
     });
 
@@ -284,7 +285,7 @@ H5P.Blanks = (function ($, Question) {
   /**
    * Create questitons html for DOM
    */
-  Blanks.prototype.createQuestions = function (labelId) {
+  Blanks.prototype.createQuestions = function () {
     var self = this;
 
     var html = '';
@@ -310,7 +311,7 @@ H5P.Blanks = (function ($, Question) {
         return cloze;
       });
 
-      html += '<div role="group" aria-labelledby="' + labelId + '">' + question + '</div>';
+      html += '<div role="group" aria-labelledby="' + self.labelId + '">' + question + '</div>';
     }
 
     self.hasClozes = clozeNumber > 0;


### PR DESCRIPTION
Some compound contents like IV instantiate the content but don't attach it to the DOM right away. Since the clozes were not created
before content is being attached, calling getMaxScore before the content was attached yielded 0 instead of the correct number.

Reported at https://h5p.org/node/1060015 and fixed here.