### PR TITLE
Fix input field opacity iOS

### DIFF
--- a/css/blanks.css
+++ b/css/blanks.css
@@ -21,6 +21,9 @@
   box-shadow: 0 0 0.5em 0 #7fb8ff;
   border-color: #7fb8ff;
 }
+.h5p-blanks .h5p-text-input:disabled {
+  opacity: 1;
+}
 .h5p-blanks .h5p-text-input.h5p-not-filled-out {
   background: #fff0f0;
 }


### PR DESCRIPTION
When an input field is set to `disabled`, then webkit sets the opacity of the field to .4. In turn, when seeing the solutions and fields are set to `disabled`, the visual appearance is way too bright.

When merged in, this issue will be fixed by setting the `opacity: 1` for all text input fields that have been disabled.