### PR TITLE
HFP-3862 Add completion/sucess flag to xAPI result

### DIFF
--- a/js/blanks.js
+++ b/js/blanks.js
@@ -766,7 +766,13 @@ H5P.Blanks = (function ($, Question) {
    *  The xAPI event we will add a response to
    */
   Blanks.prototype.addResponseToXAPI = function (xAPIEvent) {
-    xAPIEvent.setScoredResult(this.getScore(), this.getMaxScore(), this);
+    xAPIEvent.setScoredResult(
+      this.getScore(),
+      this.getMaxScore(),
+      this,
+      true, // completion
+      this.getScore() === this.getMaxScore() // success
+    );
     xAPIEvent.data.statement.result.response = this.getxAPIResponse();
   };
 


### PR DESCRIPTION
When merged in, will set the `completion` flag and the `success` flag of the xAPI `result` property.

Resolves https://github.com/h5p/h5p-blanks/issues/137