### PR TITLE
Remove tabindex attribute from hidden element in Blanks

### DIFF
--- a/js/blanks.js
+++ b/js/blanks.js
@@ -322,7 +322,6 @@ H5P.Blanks = (function ($, Question) {
 
     self.a11yHeader = document.createElement('div');
     self.a11yHeader.classList.add('hidden-but-read');
-    self.a11yHeader.tabIndex = -1;
     self.$questions[0].insertBefore(self.a11yHeader, this.$questions[0].childNodes[0] || null);
 
     // Set input fields.


### PR DESCRIPTION
https://h5ptechnology.atlassian.net/browse/HFP-4043

This resolves an issue where when navigating to a Fill in the Blanks question button in a Course Presentation using a screenreader, focus is lost when opening the Fill in the Blanks question and `title + "grouping"` is read twice. Removing the `tabindex="-1"` attribute on the hidden element in the blanks question resolves this issue.