### PR TITLE
refactor: use less common control chars

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -22,10 +22,10 @@
       "entity": "text block",
       "field": {
         "label": "Line of text",
-        "placeholder": "Oslo is the capital of *Norway*.",
+        "placeholder": "Oslo is the capital of ~Norway~.",
         "important": {
-          "description": "<ul><li>Blanks are added with an asterisk (*) in front and behind the correct word/phrase.</li><li>Alternative answers are separated with a forward slash (/).</li><li>You may add a textual tip, using a colon (:) in front of the tip.</li></ul>",
-          "example": "H5P content may be edited using a *browser/web-browser:Something you use every day*."
+          "description": "<ul><li>Blanks are added with a tilde (~) in front and behind the correct word/phrase.</li><li>Alternative answers are separated with a pipe (|).</li><li>You may add a textual tip, using a caret (^) in front of the tip.</li></ul>",
+          "example": "H5P content may be edited using a ~browser|web-browser^Something you use every day~."
         }
       }
     },

--- a/language/de.json
+++ b/language/de.json
@@ -22,10 +22,10 @@
       "entity": "Textblock",
       "field": {
         "label": "Textzeile",
-        "placeholder": "Berlin ist die Hauptstadt von *Deutschland*.",
+        "placeholder": "Berlin ist die Hauptstadt von ~Deutschland~.",
         "important": {
-          "description": "<ul><li>Lücken werden mit einem Sternchen (*) vor und hinter dem richtigen Wort markiert.</li><li>Alternative Antworten können jeweils mit einem Schrägstrich (/) angefügt werden.</li><li>Du kannst einen Tipp mit einem Doppelpunkt (:) davor hinzufügen.</li></ul>",
-          "example": "H5P-Inhalte können mit einem *Browser/Web-Browser:Etwas, das du jeden Tag nutzt* betrachtet werden."
+          "description": "<ul><li>Lücken werden mit einer 'Tilde' (~) vor und hinter dem richtigen Wort markiert.</li><li>Alternative Antworten können jeweils mit einer 'Pipe' (|) angefügt werden.</li><li>Du kannst einen Tipp mit einem 'Caret' (^) davor hinzufügen.</li></ul>",
+          "example": "H5P-Inhalte können mit einem ~Browser|Web-Browser^Etwas, das du jeden Tag nutzt~ betrachtet werden."
         }
       }
     },

--- a/semantics.json
+++ b/semantics.json
@@ -73,11 +73,10 @@
       "widget": "html",
       "label": "Line of text",
       "importance": "high",
-      "placeholder": "Oslo is the capital of *Norway*.",
-      "description": "",
+      "placeholder": "Oslo is the capital of ~Norway~.",
       "important": {
-        "description": "<ul><li>Blanks are added with an asterisk (*) in front and behind the correct word/phrase.</li><li>Alternative answers are separated with a forward slash (/).</li><li>You may add a textual tip, using a colon (:) in front of the tip.</li></ul>",
-        "example": "H5P content may be edited using a *browser/web-browser:Something you use every day*."
+          "description": "<ul><li>Blanks are added with a tilde (~) in front and behind the correct word/phrase.</li><li>Alternative answers are separated with a pipe (|).</li><li>You may add a textual tip, using a caret (^) in front of the tip.</li></ul>",
+          "example": "H5P content may be edited using a ~browser|web-browser^Something you use every day~."
       },
       "enterMode": "p",
       "tags": [


### PR DESCRIPTION
As asterisk, colon and forward slash are very commonly used characters, this content type can not be used on a variety of use cases, like HTML where the / slash is heavily used. Also the Complex-blank type does not provide a solution. 

Using less common characters for controlling the content, would allow a much broader use of this content type. And also avoid the new duplicates could evolve.

Here I suggested:

- tilde ~ instead of * for answers
- pipe | instead of / for alternatives
- caret ^ instead of : for tips

:exclamation: If this makes sense, I would update the **remaining language files** with these new characters